### PR TITLE
Add basic terraform file

### DIFF
--- a/buildstockbatch/gcp/main.tf
+++ b/buildstockbatch/gcp/main.tf
@@ -1,0 +1,74 @@
+# Terraform file to define GCP resources used by buildstock_gcp
+#
+# When setting up a new project:
+#   terraform init
+#
+# To see what changes will be applied:
+#   terraform plan
+#
+# To apply those changes:
+#   terraform apply
+#
+# Optionally set variables:
+#   terraform apply -var="gcp_project=myproject" -var="bucket_name=mybucket" -var="region=us-east1-b"
+#
+# Format this file:
+#   terraform fmt main.tf
+
+
+variable "gcp_project" {
+  type        = string
+  default     = "buildstockbatch-dev"
+  description = "GCP project to use"
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "GCS bucket where buildstockbatch inputs and outputs should be stored"
+  default     = "buildstockbatch"
+}
+
+variable "topic_name" {
+  type        = string
+  default     = "notifications"
+  description = "Pub/sub topic where batch job state change notifications will be sent"
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "GCP region where all resources will be created"
+}
+
+variable "artifact_registry_repository" {
+  type        = string
+  default     = "buildstockbatch-docker"
+  description = "Name of the artifact registry repository for storing Docker images. May contain letters, numbers, hyphens."
+}
+
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.region
+}
+
+# Pub/sub topic for job notifications
+resource "google_pubsub_topic" "notification_topic" {
+  name = var.topic_name
+}
+
+# GCS bucket for storing inputs and outputs
+resource "google_storage_bucket" "bucket" {
+  name                        = var.bucket_name
+  location                    = var.region
+  force_destroy               = false
+  uniform_bucket_level_access = true
+}
+
+# Artifact registry repository
+resource "google_artifact_registry_repository" "AR_repo" {
+  location      = var.region
+  repository_id = var.artifact_registry_repository
+  description   = "For BuildStock Batch docker images"
+  format        = "DOCKER"
+}

--- a/buildstockbatch/gcp/main.tf
+++ b/buildstockbatch/gcp/main.tf
@@ -24,8 +24,8 @@ variable "gcp_project" {
 
 variable "bucket_name" {
   type        = string
-  description = "GCS bucket where buildstockbatch inputs and outputs should be stored"
   default     = "buildstockbatch"
+  description = "GCS bucket where buildstockbatch inputs and outputs should be stored"
 }
 
 variable "topic_name" {
@@ -69,6 +69,5 @@ resource "google_storage_bucket" "bucket" {
 resource "google_artifact_registry_repository" "AR_repo" {
   location      = var.region
   repository_id = var.artifact_registry_repository
-  description   = "For BuildStock Batch docker images"
   format        = "DOCKER"
 }


### PR DESCRIPTION
**This change**
- Adds a basic terraform config to help set up GCP resources uses by BSB including:
  - Pub/sub topic for job state notifications (I'm not sure whether we'll keep this, but the job uses it now)
  - GCS bucket for storing input and output files
  - Artifact registry repo for Docker images

**Next steps**
- Add instructions for running this when setting up a new BSB project and/or apply it automatically as part of running a job. All the resources I've added (so far) can all be shared by multiple job runs, so this may make more sense as a one-time setup step.