### PR TITLE
Update settings and defaults for job resources

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -537,8 +537,7 @@ class GcpBatch(DockerBatchBase):
 
         # Specify type of VMs to run on
         policy = batch_v1.AllocationPolicy.InstancePolicy(
-            # If machine type isn't specified, GCP Batch with choose a type
-            # based on the resources requested.
+            # If machine type isn't specified, GCP Batch will choose a type based on the resources requested.
             machine_type=job_env_cfg.get('machine_type'),
             provisioning_model=(
                 batch_v1.AllocationPolicy.ProvisioningModel.SPOT

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -540,7 +540,7 @@ class GcpBatch(DockerBatchBase):
             machine_type=job_env_cfg.get('machine_type'),
             provisioning_model=(
                 batch_v1.AllocationPolicy.ProvisioningModel.SPOT
-                if gcp_cfg.get('use_spot')
+                if job_env_cfg.get('use_spot')
                 else batch_v1.AllocationPolicy.ProvisioningModel.STANDARD
             ),
         )

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -145,7 +145,6 @@ class GcpBatch(DockerBatchBase):
         self.gcs_bucket = self.cfg['gcp']['gcs']['bucket']
         self.gcs_prefix = self.cfg['gcp']['gcs']['prefix']
         self.batch_array_size = self.cfg['gcp']['batch_array_size']
-        self.use_spot = self.cfg['gcp'].get('use_spot', False)
 
         # Add timestamp to job ID, since duplicates aren't allowed (even between finished and new jobs)
         # TODO: stop appending timestamp here - it's useful for testing, but we should probably

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -513,7 +513,7 @@ class GcpBatch(DockerBatchBase):
 
         runnable.container.commands = ['-c', 'python3 -m buildstockbatch.gcp.gcp']
 
-        job_env_cfg = self.cfg['gcp'].get('job_environment', {})
+        job_env_cfg = gcp_cfg.get('job_environment', {})
         resources = batch_v1.ComputeResource(
             cpu_milli=1000 * job_env_cfg.get('vcpus', 1),
             memory_mib=job_env_cfg.get('memory_mib', 1024),

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -27,8 +27,7 @@ gcp-spec:
   # TODO: notifications_email is not yet used/supported. Also update project_defn when it is.
   # notifications_email: regex('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', name='email', required=True)
   gcs: include('gcs-spec', required=True)
-  use_spot: bool(required=False)
-  job_environment: include('gcp-job-environment', required=False)
+  job_environment: include('gcp-job-environment-spec', required=False)
 
 gcs-spec:
   bucket: str(required=True)
@@ -37,10 +36,11 @@ gcs-spec:
 gcp-ar-spec:
   repository: str(required=True)
 
-gcp-job-environment:
+gcp-job-environment-spec:
   vcpus: int(min=1, max=224, required=False)
   memory_mib: int(min=512, required=False)
   machine_type: str(required=False)
+  use_spot: bool(required=False)
 
 aws-spec:
   job_identifier: regex('^[a-zA-Z]\w{,9}$', required=True)

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -28,6 +28,7 @@ gcp-spec:
   # notifications_email: regex('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', name='email', required=True)
   gcs: include('gcs-spec', required=True)
   use_spot: bool(required=False)
+  job_environment: include('gcp-job-environment', required=False)
 
 gcs-spec:
   bucket: str(required=True)
@@ -35,6 +36,11 @@ gcs-spec:
 
 gcp-ar-spec:
   repository: str(required=True)
+
+gcp-job-environment:
+  vcpus: int(min=1, max=224, required=False)
+  memory_mib: int(min=512, required=False)
+  machine_type: str(required=False)
 
 aws-spec:
   job_identifier: regex('^[a-zA-Z]\w{,9}$', required=True)

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -254,7 +254,7 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     * ``vcpus``: Number of CPUs to allocate for running each simulation. Default: 1.
     * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024.
       For large multifamily buildings this works better if set to 2048.
-    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP batch will
+    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP Batch will
       choose a machine type based on the requested vCPUs and memory. If set, the machine type
       should have at least as many resources as requested for each simulation above. If it is
       large enough, multiple simulations will be run in parallel on the same machine.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -243,9 +243,6 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     *  ``prefix``: The Cloud Storage prefix at which the data will be stored.
 
 *  ``region``: The GCP region in which the batch will be run and of the Artifact Registry.
-*  ``use_spot``: true or false. Defaults to false if missing. This tells the project
-   to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
-   simulations, which can reduce costs by up to 91%.
 *  ``batch_array_size``: Number of concurrent simulations to run. Max: 10000.
 *  ``artifact_registry``: Configuration for Docker image storage in GCP Artifact Registry
 
@@ -254,10 +251,16 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
       repository.
 *  ``job_environment``: Optional. Specifies the computing requirements for each simulation.
 
-    * ``vcpus``: Number of CPUs needed. Default: 1.
-    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024. For large multifamily buildings
-      this works better if set to 2048.
-    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP batch will choose a machine type based on the requested vCPUs and memory.
+    * ``vcpus``: Number of CPUs to allocate for running each simulation. Default: 1.
+    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024.
+      For large multifamily buildings this works better if set to 2048.
+    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP batch will
+      choose a machine type based on the requested vCPUs and memory. If set, the machine type
+      should have at least as many resources as requested for each simulation above. If it is
+      large enough, multiple simulations will be run in parallel on the same machine.
+    * ``use_spot``: true or false. Defaults to false if missing. This tells the project
+      to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
+      simulations, which can reduce costs by up to 91%.
 
 .. _postprocessing:
 

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -246,21 +246,21 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
 *  ``batch_array_size``: Number of concurrent simulations to run. Max: 10000.
 *  ``artifact_registry``: Configuration for Docker image storage in GCP Artifact Registry
 
-    * ``repository``: The name of the GCP Artifact Repository in which Docker images are stored.
-      This will be combined with the ``project`` and ``region`` to build the full URL to the
-      repository.
+    *  ``repository``: The name of the GCP Artifact Repository in which Docker images are stored.
+       This will be combined with the ``project`` and ``region`` to build the full URL to the
+       repository.
 *  ``job_environment``: Optional. Specifies the computing requirements for each simulation.
 
-    * ``vcpus``: Number of CPUs to allocate for running each simulation. Default: 1.
-    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024.
-      For large multifamily buildings this works better if set to 2048.
-    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP Batch will
-      choose a machine type based on the requested vCPUs and memory. If set, the machine type
-      should have at least as many resources as requested for each simulation above. If it is
-      large enough, multiple simulations will be run in parallel on the same machine.
-    * ``use_spot``: true or false. Defaults to false if missing. This tells the project
-      to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
-      simulations, which can reduce costs by up to 91%.
+    *  ``vcpus``: Number of CPUs to allocate for running each simulation. Default: 1.
+    *  ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024.
+       For large multifamily buildings this works better if set to 2048.
+    *  ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP Batch will
+       choose a machine type based on the requested vCPUs and memory. If set, the machine type
+       should have at least as many resources as requested for each simulation above. If it is
+       large enough, multiple simulations will be run in parallel on the same machine.
+    *  ``use_spot``: true or false. Defaults to false if missing. This tells the project
+       to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
+       simulations, which can reduce costs by up to 91%.
 
 .. _postprocessing:
 

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -252,6 +252,12 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     * ``repository``: The name of the GCP Artifact Repository in which Docker images are stored.
       This will be combined with the ``project`` and ``region`` to build the full URL to the
       repository.
+*  ``job_environment``: Specifies the computing requirements for each simulation.
+
+    * ``vcpus``: Number of CPUs needed. default: 1.
+    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. default 1024. For large multifamily buildings
+      this works better if set to 2048.
+    * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP batch will choose a machine type based on the requested vCPUs and memory.
 
 .. _postprocessing:
 

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -252,10 +252,10 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     * ``repository``: The name of the GCP Artifact Repository in which Docker images are stored.
       This will be combined with the ``project`` and ``region`` to build the full URL to the
       repository.
-*  ``job_environment``: Specifies the computing requirements for each simulation.
+*  ``job_environment``: Optional. Specifies the computing requirements for each simulation.
 
-    * ``vcpus``: Number of CPUs needed. default: 1.
-    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. default 1024. For large multifamily buildings
+    * ``vcpus``: Number of CPUs needed. Default: 1.
+    * ``memory_mib``: Amount of RAM memory needed for each simulation in MiB. Default: 1024. For large multifamily buildings
       this works better if set to 2048.
     * ``machine_type``: GCP Compute Engine machine type to use. If omitted, GCP batch will choose a machine type based on the requested vCPUs and memory.
 

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -140,7 +140,7 @@ file, something like this:
         bucket: mybucket
         prefix: national01_run01
       use_spot: true
-      batch_array_size: 10000
+      batch_array_size: 100
       notifications_email: your_email@somewhere.com
 
 See :ref:`gcp-config` for details.

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -140,7 +140,7 @@ file, something like this:
         bucket: mybucket
         prefix: national01_run01
       use_spot: true
-      batch_array_size: 100
+      batch_array_size: 10000
       notifications_email: your_email@somewhere.com
 
 See :ref:`gcp-config` for details.


### PR DESCRIPTION
Add optional config params for resources allocated to each task, including:
- vCPU
- memory
- machine type

All of these are optional, with the same defaults as on AWS. See notes about some test runs [here](https://docs.google.com/document/d/19j6qRco5HyLEeQFZBSrLwJJ1in2HnkoVg1Y6weBfeq8/edit#heading=h.sa6k11iebf7t).

Max and mins in the schema are based on what GCP Batch allows.