### PR TITLE
Show status of individual tasks

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -355,13 +355,12 @@ class GcpBatch(DockerBatchBase):
         logger.info(f'Showing the first 10 existing jobs that match: {request.filter}\n')
         response = client.list_jobs(request)
         for job in response.jobs:
-            task_counts = collections.defaultdict(int)
             logger.debug(job)
             logger.info(f'Name: {job.name}')
             logger.info(f'  UID: {job.uid}')
             logger.info(f'  Status: {job.status.state.name}')
-            task_groups = job.status.task_groups
-            for group in task_groups.values():
+            task_counts = collections.defaultdict(int)
+            for group in job.status.task_groups.values():
                 for status, count in group.counts.items():
                     task_counts[status] += count
             logger.info(f'  Task statuses: {dict(task_counts)}')

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -355,10 +355,16 @@ class GcpBatch(DockerBatchBase):
         logger.info(f'Showing the first 10 existing jobs that match: {request.filter}\n')
         response = client.list_jobs(request)
         for job in response.jobs:
+            task_counts = collections.defaultdict(int)
             logger.debug(job)
             logger.info(f'Name: {job.name}')
             logger.info(f'  UID: {job.uid}')
             logger.info(f'  Status: {job.status.state.name}')
+            task_groups = job.status.task_groups
+            for group in task_groups.values():
+                for status, count in group.counts.items():
+                    task_counts[status] += count
+            logger.info(f'  Task statuses: {dict(task_counts)}')
 
     def run_batch(self):
         """


### PR DESCRIPTION
Small update to the `--list_jobs` option: show the status of the tasks.

This is helpful when checking on in-progress jobs, to see how many of the batches have finished.

Sample output:
```
INFO:2023-11-01 19:06:53:buildstockbatch.gcp.gcp:Name: projects/buildstockbatch-dev/locations/us-central1/jobs/natalie10023-11-01-185441
INFO:2023-11-01 19:06:53:buildstockbatch.gcp.gcp:  UID: natalie10023-11-01-f66fb0dc-625f-434d0
INFO:2023-11-01 19:06:53:buildstockbatch.gcp.gcp:  Status: RUNNING
INFO:2023-11-01 19:06:53:buildstockbatch.gcp.gcp:  Task statuses: {'RUNNING': 3, 'SUCCEEDED': 2}
```