### PR TITLE
Refactor: Start sharing code between GCP and AWS implementations

### DIFF
--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -16,10 +16,8 @@ import boto3
 from botocore.exceptions import ClientError
 import collections
 import csv
-import docker
 from fsspec.implementations.local import LocalFileSystem
 import gzip
-import hashlib
 import itertools
 from joblib import Parallel, delayed
 import json
@@ -38,10 +36,16 @@ import time
 import io
 import zipfile
 
-from buildstockbatch.base import ValidationError, BuildStockBatchBase
+from buildstockbatch.base import ValidationError, DockerBatchBase
 from buildstockbatch.aws.awsbase import AwsJobBase
 from buildstockbatch import postprocessing
-from buildstockbatch.utils import ContainerRuntime, log_error_details, get_project_configuration, read_csv
+from buildstockbatch.utils import (
+    calc_hash_for_file,
+    compress_file,
+    get_project_configuration,
+    log_error_details,
+    read_csv,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,17 +77,6 @@ def upload_directory_to_s3(local_directory, bucket, prefix):
         for local_file, s3_key
         in filename_generator()
     )
-
-
-def compress_file(in_filename, out_filename):
-    with gzip.open(str(out_filename), 'wb') as f_out:
-        with open(str(in_filename), 'rb') as f_in:
-            shutil.copyfileobj(f_in, f_out)
-
-
-def calc_hash_for_file(filename):
-    with open(filename, 'rb') as f:
-        return hashlib.sha256(f.read()).hexdigest()
 
 
 def copy_s3_file(src_bucket, src_key, dest_bucket, dest_key):
@@ -1655,29 +1648,6 @@ class AwsSNS(AwsJobBase):
         )
 
         logger.info(f"Simple notifications topic {self.sns_state_machine_topic} deleted.")
-
-
-class DockerBatchBase(BuildStockBatchBase):
-
-    CONTAINER_RUNTIME = ContainerRuntime.DOCKER
-
-    def __init__(self, project_filename):
-        super().__init__(project_filename)
-
-        self.docker_client = docker.DockerClient.from_env()
-        try:
-            self.docker_client.ping()
-        except:  # noqa: E722 (allow bare except in this case because error can be a weird non-class Windows API error)
-            logger.error('The docker server did not respond, make sure Docker Desktop is started then retry.')
-            raise RuntimeError('The docker server did not respond, make sure Docker Desktop is started then retry.')
-
-    @staticmethod
-    def validate_project(project_file):
-        super(DockerBatchBase, DockerBatchBase).validate_project(project_file)
-
-    @property
-    def docker_image(self):
-        return 'nrel/openstudio:{}'.format(self.os_version)
 
 
 class AwsBatch(DockerBatchBase):

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -19,11 +19,9 @@ import argparse
 import collections
 import csv
 from datetime import datetime
-import docker
 from fsspec.implementations.local import LocalFileSystem
 import gcsfs
 import gzip
-import hashlib
 from joblib import Parallel, delayed
 import json
 import io
@@ -47,35 +45,18 @@ from google.cloud.storage import transfer_manager
 from google.cloud import compute_v1
 
 from buildstockbatch import postprocessing
-from buildstockbatch.base import BuildStockBatchBase
+from buildstockbatch.base import DockerBatchBase
 from buildstockbatch.exc import ValidationError
-from buildstockbatch.utils import ContainerRuntime, get_project_configuration, log_error_details, read_csv
+from buildstockbatch.utils import (
+    calc_hash_for_file,
+    compress_file,
+    get_project_configuration,
+    log_error_details,
+    read_csv,
+)
 
 
 logger = logging.getLogger(__name__)
-
-
-# todo: aws-shared (see file comment)
-class DockerBatchBase(BuildStockBatchBase):
-    CONTAINER_RUNTIME = ContainerRuntime.DOCKER
-
-    def __init__(self, project_filename):
-        super().__init__(project_filename)
-
-        self.docker_client = docker.DockerClient.from_env()
-        try:
-            self.docker_client.ping()
-        except:  # noqa: E722 (allow bare except in this case because error can be a weird non-class Windows API error)
-            logger.error('The docker server did not respond, make sure Docker Desktop is started then retry.')
-            raise RuntimeError('The docker server did not respond, make sure Docker Desktop is started then retry.')
-
-    @staticmethod
-    def validate_project(project_file):
-        super(DockerBatchBase, DockerBatchBase).validate_project(project_file)
-
-    @property
-    def docker_image(self):
-        return f"nrel/openstudio:{self.os_version}"
 
 
 def upload_directory_to_GCS(local_directory, bucket, prefix):
@@ -99,19 +80,6 @@ def upload_directory_to_GCS(local_directory, bucket, prefix):
         blob_name_prefix=prefix,
         raise_exception=True,
     )
-
-
-# todo: aws-shared (see file comment)
-def compress_file(in_filename, out_filename):
-    with gzip.open(str(out_filename), 'wb') as f_out:
-        with open(str(in_filename), 'rb') as f_in:
-            shutil.copyfileobj(f_in, f_out)
-
-
-# todo: aws-shared (see file comment)
-def calc_hash_for_file(filename):
-    with open(filename, 'rb') as f:
-        return hashlib.sha256(f.read()).hexdigest()
 
 
 def copy_GCS_file(src_bucket, src_name, dest_bucket, dest_name):

--- a/buildstockbatch/utils.py
+++ b/buildstockbatch/utils.py
@@ -1,10 +1,12 @@
 import enum
+import gzip
 import inspect
-import os
 import logging
+import os
+import pandas as pd
+import shutil
 import traceback
 import yaml
-import pandas as pd
 
 
 logger = logging.getLogger(__name__)
@@ -114,3 +116,15 @@ def log_error_details(output_file="buildstockbatch_crash_details.log"):
         return run_with_error_capture
 
     return log_error_decorator
+
+
+def compress_file(in_filename, out_filename):
+    """Compress a file using gzip."""
+    with gzip.open(str(out_filename), 'wb') as f_out:
+        with open(str(in_filename), 'rb') as f_in:
+            shutil.copyfileobj(f_in, f_out)
+
+def calc_hash_for_file(filename):
+    """Calculate the SHA-256 hash of a file, as a hex string."""
+    with open(filename, 'rb') as f:
+        return hashlib.sha256(f.read()).hexdigest()


### PR DESCRIPTION
This just does the easiest bit of refactoring, by sharing classes and functions that were exact copies.