### PR TITLE
Show batch job progress

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -589,21 +589,21 @@ class GcpBatch(DockerBatchBase):
         created_job = client.create_job(create_request)
         job_name = created_job.name
 
-        logger.info('Newly created GCP Batch job')
-        logger.info(f'  Job name: {job_name}')
-        logger.info(f'  Job UID: {created_job.uid}')
+        logger.info("Newly created GCP Batch job")
+        logger.info(f"  Job name: {job_name}")
+        logger.info(f"  Job UID: {created_job.uid}")
         job_url = (
-            'https://console.cloud.google.com/batch/jobsDetail/regions/'
-            f'{self.region}/jobs/{self.unique_job_id}/details?project={self.gcp_project}'
+            "https://console.cloud.google.com/batch/jobsDetail/regions/"
+            f"{self.region}/jobs/{self.unique_job_id}/details?project={self.gcp_project}"
         )
-        logger.info(f'View job at {job_url}')
+        logger.info(f"View GCP Batch job at {job_url}")
 
         # Monitor job status while waiting for the job to complete
         n_succeeded_last_time = 0
         client = batch_v1.BatchServiceClient()
-        with tqdm.tqdm(desc="Running Simulations", total=task_count, unit='batch') as progress_bar:
+        with tqdm.tqdm(desc="Running Simulations", total=task_count, unit="batch") as progress_bar:
             job_status = None
-            while job_status not in ('SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS'):
+            while job_status not in ("SUCCEEDED", "FAILED", "DELETION_IN_PROGRESS"):
                 time.sleep(10)
                 job_info = client.get_job(batch_v1.GetJobRequest(name=job_name))
                 job_status = job_info.status.state.name
@@ -612,11 +612,15 @@ class GcpBatch(DockerBatchBase):
                 for group in job_info.status.task_groups.values():
                     for status, count in group.counts.items():
                         task_counts[status] += count
-                n_succeeded = task_counts.get('SUCCEEDED', 0)
+                n_succeeded = task_counts.get("SUCCEEDED", 0)
                 progress_bar.update(n_succeeded - n_succeeded_last_time)
                 n_succeeded_last_time = n_succeeded
                 # Show all task status counts next to the progress bar
                 progress_bar.set_postfix_str(f'{dict(task_counts)}')
+
+        logger.info(f"Batch job status: {job_status}")
+        if job_status != "SUCCEEDED":
+            raise RuntimeError("Batch job failed. See GCP logs at {job_url}")
 
     @classmethod
     def run_task(cls, task_index, job_name, gcs_bucket, gcs_prefix):

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -39,6 +39,7 @@ import subprocess
 import tarfile
 import tempfile
 import time
+import tqdm
 
 from google.api_core import exceptions
 from google.cloud import artifactregistry_v1
@@ -586,10 +587,36 @@ class GcpBatch(DockerBatchBase):
 
         # Start the job!
         created_job = client.create_job(create_request)
+        job_name = created_job.name
 
         logger.info('Newly created GCP Batch job')
-        logger.info(f'  Job name: {created_job.name}')
+        logger.info(f'  Job name: {job_name}')
         logger.info(f'  Job UID: {created_job.uid}')
+        job_url = (
+            'https://console.cloud.google.com/batch/jobsDetail/regions/'
+            f'{self.region}/jobs/{self.unique_job_id}/details?project={self.gcp_project}'
+        )
+        logger.info(f'View job at {job_url}')
+
+        # Monitor job status while waiting for the job to complete
+        n_succeeded_last_time = 0
+        client = batch_v1.BatchServiceClient()
+        with tqdm.tqdm(desc="Running Simulations", total=task_count, unit='batch') as progress_bar:
+            job_status = None
+            while job_status not in ('SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS'):
+                time.sleep(10)
+                job_info = client.get_job(batch_v1.GetJobRequest(name=job_name))
+                job_status = job_info.status.state.name
+                # Check how many tasks have succeeded
+                task_counts = collections.defaultdict(int)
+                for group in job_info.status.task_groups.values():
+                    for status, count in group.counts.items():
+                        task_counts[status] += count
+                n_succeeded = task_counts.get('SUCCEEDED', 0)
+                progress_bar.update(n_succeeded - n_succeeded_last_time)
+                n_succeeded_last_time = n_succeeded
+                # Show all task status counts next to the progress bar
+                progress_bar.set_postfix_str(f'{dict(task_counts)}')
 
     @classmethod
     def run_task(cls, task_index, job_name, gcs_bucket, gcs_prefix):

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         'google-cloud-batch',
         'google-cloud-compute',
         'google-cloud-storage',
+        'tqdm',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
After launching a GPC Batch job, wait for it to finish before exiting. Also display a progress bar that shows how many of the batch tasks have succeeded.

This is based on the AWS version [here](https://github.com/NREL/buildstockbatch/blob/9f02478dc45b619cb63cf39b949b610b2d7ae606/buildstockbatch/aws/aws.py#L1514).

Also switching to double quotes, since [they've started enforcing that convention](https://github.com/NREL/buildstockbatch/pull/403). We can clean up the rest of the file in a separate PR.