### PR TITLE
Remove notifications email option

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -572,19 +572,6 @@ class GcpBatch(DockerBatchBase):
         job.logs_policy = batch_v1.LogsPolicy()
         job.logs_policy.destination = batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
 
-        # Send notifications to pub/sub when the job's state changes
-        # TODO: Turn these into emails if an email address is provided?
-        job.notifications = [
-            batch_v1.JobNotification(
-                # TODO: Get topic from config or create a new one as needed (via terraform)
-                pubsub_topic='projects/buildstockbatch-dev/topics/notifications',
-                message=batch_v1.JobNotification.Message(
-                    type_=1,
-                    new_job_state='STATE_UNSPECIFIED',  # notify on any changes
-                ),
-            )
-        ]
-
         create_request = batch_v1.CreateJobRequest()
         create_request.job = job
         create_request.job_id = self.unique_job_id

--- a/buildstockbatch/gcp/main.tf
+++ b/buildstockbatch/gcp/main.tf
@@ -28,12 +28,6 @@ variable "bucket_name" {
   description = "GCS bucket where buildstockbatch inputs and outputs should be stored"
 }
 
-variable "topic_name" {
-  type        = string
-  default     = "notifications"
-  description = "Pub/sub topic where batch job state change notifications will be sent"
-}
-
 variable "region" {
   type        = string
   default     = "us-central1"
@@ -50,11 +44,6 @@ variable "artifact_registry_repository" {
 provider "google" {
   project = var.gcp_project
   region  = var.region
-}
-
-# Pub/sub topic for job notifications
-resource "google_pubsub_topic" "notification_topic" {
-  name = var.topic_name
 }
 
 # GCS bucket for storing inputs and outputs

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -27,8 +27,6 @@ gcp-spec:
   region: str(required=True)
   artifact_registry: include('gcp-ar-spec', required=True)
   batch_array_size: num(min=1, max=10000, required=True)
-  # TODO: notifications_email is not yet used/supported. Also update project_defn when it is.
-  # notifications_email: regex('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', name='email', required=True)
   gcs: include('gcs-spec', required=True)
   job_environment: include('gcp-job-environment-spec', required=False)
 

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -141,7 +141,6 @@ file, something like this:
         prefix: national01_run01
       use_spot: true
       batch_array_size: 10000
-      notifications_email: your_email@somewhere.com
 
 See :ref:`gcp-config` for details.
 


### PR DESCRIPTION
Remove the option for notification emails because
1) It's less straightforward to set up on GCP, and
2) Now that the script blocks on the job completing, it's less useful.