### PR TITLE
Move coverage report to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-  pull_request_target:
+  pull_request:
     types:
       - synchronize
       - opened
@@ -67,14 +67,18 @@ jobs:
         with:
           name: coverage-report-html
           path: buildstockbatch/coverage/htmlreport/
-      - name: Report coverage to PR
-        uses: 5monkeys/cobertura-action@v13
+      - name: Save Coverage Report XML
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.python-version == '3.11' }}
         with:
+          name: coverage-report-xml
           path: buildstockbatch/coverage/coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_coverage: 33
-          fail_below_threshold: true
+      - name: Coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: coverage/cobertura-coverage.xml
+
       - name: Build documentation
         if: ${{ matrix.python-version == '3.11' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,6 @@ jobs:
         with:
           name: coverage-report-xml
           path: buildstockbatch/coverage/coverage.xml
-      - name: Coverage
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage
-          path: coverage/cobertura-coverage.xml
-
       - name: Build documentation
         if: ${{ matrix.python-version == '3.11' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-  pull_request:
+  pull_request_target:
     types:
       - synchronize
       - opened

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,9 @@ jobs:
 
         # This step is here instead of in ci.yml because PRs from other forks
         # do not have write permission to the PR during a pull_request action.
+        # More information:
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+        # Example to follow:
         # https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows
       - name: Report coverage to PR
         uses: 5monkeys/cobertura-action@v13

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Coverage report
+
+on:
+  workflow_run:
+    workflows: ["BuildStockBatch Tests"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+
+      - name: Download Coverage Artifacts
+        uses: Legit-Labs/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          name: coverage-report-xml
+          path: buildstockbatch/coverage
+
+        # This step is here instead of in ci.yml because PRs from other forks
+        # do not have write permission to the PR during a pull_request action.
+        # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+        # https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows
+      - name: Report coverage to PR
+        uses: 5monkeys/cobertura-action@v13
+        if: ${{ matrix.python-version == '3.11' }}
+        with:
+          path: buildstockbatch/coverage/coverage.xml
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          minimum_coverage: 33
+          fail_below_threshold: true


### PR DESCRIPTION
Following the guidance [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) and the example [here](https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows), move the code coverage report out of the `pull_request` action, so it can run for PRs from other forks. (i.e. when we send PRs to NREL/buildstockbatch)