### PR TITLE
Log basic job stats

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -652,7 +652,7 @@ class GcpBatch(DockerBatchBase):
             append_stat("Simulations", n_sims)
             append_stat("Tasks", task_group.task_count)
             append_stat("Parallelism", task_group.parallelism)
-            append_stat("milliCPU/task", task_spec.compute_resource.cpu_milli)
+            append_stat("mCPU/task", task_spec.compute_resource.cpu_milli)
             append_stat("MiB/task", task_spec.compute_resource.memory_mib)
             append_stat("Machine type", instance.machine_type)
             append_stat("Provisioning", instance.provisioning_model.name)

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -634,6 +634,32 @@ class GcpBatch(DockerBatchBase):
         logger.info(f"Batch job status: {job_status}")
         if job_status != "SUCCEEDED":
             raise RuntimeError("Batch job failed. See GCP logs at {job_url}")
+        else:
+            task_group = job_info.task_groups[0]
+            task_spec = task_group.task_spec
+            instance = job_info.status.task_groups["group0"].instances[0]
+
+            # Format stats for easy copying into a spreadsheet
+            keys, values = [], []
+
+            def append_stat(key, value):
+                nonlocal keys
+                nonlocal values
+                width = max(len(str(key)), len(str(value)))
+                keys.append(str(key).rjust(width))
+                values.append(str(value).rjust(width))
+
+            append_stat("Simulations", n_sims)
+            append_stat("Tasks", task_group.task_count)
+            append_stat("Parallelism", task_group.parallelism)
+            append_stat("milliCPU/task", task_spec.compute_resource.cpu_milli)
+            append_stat("MiB/task", task_spec.compute_resource.memory_mib)
+            append_stat("Machine type", instance.machine_type)
+            append_stat("Provisioning", instance.provisioning_model.name)
+            append_stat("Runtime", job_info.status.run_duration)
+
+            logger.info("\t".join(keys))
+            logger.info("\t".join(values))
 
     @classmethod
     def run_task(cls, task_index, job_name, gcs_bucket, gcs_prefix):


### PR DESCRIPTION
When the GCP Batch job finishes, log some stats about the resources it used and how long it took.

Example output:
```
INFO:2023-11-15 17:30:05:buildstockbatch.gcp.gcp:Batch job status: SUCCEEDED
INFO:2023-11-15 17:30:05:buildstockbatch.gcp.gcp:Simulations	Tasks	Parallelism	milliCPU/task	MiB/task	Machine type	Provisioning	       Runtime
INFO:2023-11-15 17:30:05:buildstockbatch.gcp.gcp:         10	    2	          2	         1000	    1024	e2-highcpu-2	        SPOT	0:05:53.855511
```