### PR TITLE
Validate post-processing settings

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -202,6 +202,7 @@ class GcpBatch(DockerBatchBase):
             memory = pp_env.get("memory_mib", GcpBatch.DEFAULT_PP_MEMORY_MIB)
 
             # Allowable values are documented at:
+            # https://cloud.google.com/python/docs/reference/run/latest/google.cloud.run_v2.types.ResourceRequirements
             # https://cloud.google.com/run/docs/configuring/services/cpu
             # https://cloud.google.com/run/docs/configuring/services/memory-limits
             cpus_to_memory_limits = {

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -203,24 +203,22 @@ class GcpBatch(DockerBatchBase):
 
             # Allowable values are documented at:
             # https://cloud.google.com/python/docs/reference/run/latest/google.cloud.run_v2.types.ResourceRequirements
-            # https://cloud.google.com/run/docs/configuring/services/cpu
-            # https://cloud.google.com/run/docs/configuring/services/memory-limits
             cpus_to_memory_limits = {
                 1: (512, 4096),
                 2: (512, 8192),
                 4: (2048, 16384),
-                8: (4096, 327681),
+                8: (4096, 32768),
             }
 
-            assert cpus in cpus_to_memory_limits, "gcp.postprocessing_environment.cpus must be 1, 2, 4 or 8"
+            assert cpus in cpus_to_memory_limits, "gcp.postprocessing_environment.cpus must be 1, 2, 4 or 8."
             min_memory, max_memory = cpus_to_memory_limits[cpus]
-            assert min_memory <= memory, (
+            assert memory >= min_memory, (
                 f"gcp.postprocessing_environment.memory_mib must be at least {min_memory} for {cpus} CPUs. "
-                f"(Found {memory})"
+                f"(Found {memory}) See https://cloud.google.com/run/docs/configuring/services/cpu"
             )
             assert memory <= max_memory, (
                 f"gcp.postprocessing_environment.memory_mib must be less than or equal to {max_memory} for {cpus} CPUs "
-                f"(Found {memory})"
+                f"(Found {memory}) See https://cloud.google.com/run/docs/configuring/services/memory-limits"
             )
 
     @staticmethod

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -45,8 +45,11 @@ gcp-job-environment-spec:
   use_spot: bool(required=False)
 
 gcp-postprocessing_environment-spec:
+  # Limits documented at
+  # https://cloud.google.com/run/docs/configuring/services/memory-limits
+  # https://cloud.google.com/run/docs/configuring/services/cpu
   cpus: int(min=1, max=8, required=False)
-  memory_mib: int(min=512, required=False)
+  memory_mib: int(min=512, max=32768, required=False)
 
 aws-spec:
   job_identifier: regex('^[a-zA-Z]\w{,9}$', required=True)

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -45,7 +45,7 @@ gcp-job-environment-spec:
   use_spot: bool(required=False)
 
 gcp-postprocessing_environment-spec:
-  cpus: int(min=1, max=224, required=False)
+  cpus: int(min=1, max=8, required=False)
   memory_mib: int(min=512, required=False)
 
 aws-spec:


### PR DESCRIPTION
Finish validation of GCP settings.

Adds checks for the post-processing resource settings, similar to the AWS checks [here](https://github.com/NREL/buildstockbatch/blob/9f02478dc45b619cb63cf39b949b610b2d7ae606/buildstockbatch/aws/aws.py#L1165) but based on the requirements from GCP.