### PR TITLE
Include AR docker images in cleanup

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -381,6 +381,8 @@ class GcpBatch(DockerBatchBase):
     def clean(self):
         delete_job(self.gcp_batch_job_name)
         self.clean_postprocessing_job()
+        # TODO: Delete Docker image
+        # TODO: Prune local docker images
 
     def show_jobs(self):
         """

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -160,6 +160,11 @@ class GcpBatch(DockerBatchBase):
         self.batch_array_size = self.cfg["gcp"]["batch_array_size"]
 
     @staticmethod
+    def get_AR_repo_name(gcp_project, region, repo):
+        """Returns the full name of a repository in Artifact Registry."""
+        return f"projects/{gcp_project}/locations/{region}/repositories/{repo}"
+
+    @staticmethod
     def validate_gcp_args(project_file):
         cfg = get_project_configuration(project_file)
         assert "gcp" in cfg, 'Project config must contain a "gcp" section'
@@ -184,7 +189,7 @@ class GcpBatch(DockerBatchBase):
         # Check that artifact registry repository exists
         repo = cfg["gcp"]["artifact_registry"]["repository"]
         ar_client = artifactregistry_v1.ArtifactRegistryClient()
-        repo_name = f"projects/{gcp_project}/locations/{region}/repositories/{repo}"
+        repo_name = GcpBatch.get_AR_repo_name(gcp_project, region, repo)
         try:
             ar_client.get_repository(name=repo_name)
         except exceptions.NotFound:
@@ -384,13 +389,13 @@ class GcpBatch(DockerBatchBase):
 
         # Clean up images in Artifact Registry
         ar_client = artifactregistry_v1.ArtifactRegistryClient()
-        repository = f"projects/{self.gcp_project}/locations/{self.region}/repositories/{self.ar_repo}"
-        package = f"{repository}/packages/buildstockbatch"
+        repo_name = self.get_AR_repo_name(self.gcp_project, self.region, self.ar_repo)
+        package = f"{repo_name}/packages/buildstockbatch"
         # Delete the tag used by this job
         try:
             ar_client.delete_tag(name=f"{package}/tags/{self.job_identifier}")
         except exceptions.NotFound:
-            pass
+            logger.debug(f"No `{self.job_identifier}` tag found in Aritfact Registry")
 
         # Then delete all untagged versions
         all_versions = ar_client.list_versions(

--- a/buildstockbatch/gcp/main.tf
+++ b/buildstockbatch/gcp/main.tf
@@ -56,7 +56,17 @@ resource "google_storage_bucket" "bucket" {
 
 # Artifact registry repository
 resource "google_artifact_registry_repository" "AR_repo" {
+  provider      = google-beta
   location      = var.region
   repository_id = var.artifact_registry_repository
   format        = "DOCKER"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    id     = "delete-old-images"
+    action = "DELETE"
+    condition {
+      tag_state    = "ANY"
+      older_than   = "2592000s"  # 30 days
+    }
+  }
 }

--- a/buildstockbatch/gcp/main.tf
+++ b/buildstockbatch/gcp/main.tf
@@ -46,6 +46,11 @@ provider "google" {
   region  = var.region
 }
 
+provider "google-beta" {
+  project = var.gcp_project
+  region  = var.region
+}
+
 # GCS bucket for storing inputs and outputs
 resource "google_storage_bucket" "bucket" {
   name                        = var.bucket_name


### PR DESCRIPTION
I'm not sure what's standard here, but I went with this (open to other suggestions!):
- If using terraform to set up AR, automatically delete images older than 30 days
- When running with `--clean` remove the job's tag, then delete any untagged `buildstockbatch` images. If the same image is being used by another job, it will be left alone, because it will have a second tag.