### PR TITLE
Quickly fail if an existing job has the same ID

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -1178,9 +1178,11 @@ def main():
         elif args.crawl:
             batch.process_results(skip_combine=True, use_dask_cluster=False)
         else:
-            if batch.get_existing_batch_job():
+            existing_job = batch.get_existing_batch_job()
+            if existing_job:
+                job_status = existing_job.status.state.name
                 logger.error(
-                    f"A job with this ID ({batch.job_identifier}) already exists. "
+                    f"A job with this ID ({batch.job_identifier}) already exists (status: {job_status}). "
                     "Choose a new job_identifier or run with --clean to delete the existing job."
                 )
                 return

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -456,8 +456,7 @@ class GcpBatch(DockerBatchBase):
         Show the existing GCP Batch and Cloud Run jobs that match the provided project, if they exist.
         """
         # GCP Batch job that runs the simulations
-        job = self.get_existing_batch_job()
-        if job:
+        if job := self.get_existing_batch_job():
             logger.info("Batch job")
             logger.info(f"  Name: {job.name}")
             logger.info(f"  UID: {job.uid}")
@@ -495,6 +494,41 @@ class GcpBatch(DockerBatchBase):
             return job
         except exceptions.NotFound:
             return None
+
+    def get_existing_postprocessing_job(self):
+        jobs_client = run_v2.JobsClient()
+        try:
+            job = jobs_client.get_job(name=self.postprocessing_job_name)
+            return job
+        except exceptions.NotFound:
+            return False
+
+    def check_for_existing_jobs(self, pp_only=False):
+        """If there are existing jobs with the same ID as this job, logs them as errors and returns True.
+
+        Otherwise, returns False.
+
+        :param pp_only: If true, only check for the post-processing job.
+        """
+        if pp_only:
+            existing_batch_job = None
+        else:
+            if existing_batch_job := self.get_existing_batch_job():
+                logger.error(
+                    f"A Batch job with this ID ({self.job_identifier}) already exists "
+                    f"(status: {existing_batch_job.status.state.name}). Choose a new job_identifier or run with "
+                    "--clean to delete the existing job."
+                )
+        if existing_pp_job := self.get_existing_postprocessing_job():
+            status = "Running"
+            if existing_pp_job.latest_created_execution.completion_time:
+                status = "Completed"
+            logger.error(
+                f"A Cloud Run job with this ID ({self.postprocessing_job_id}) already exists "
+                f"(status: {status}). Choose a new job_identifier or run with --clean "
+                "to delete the existing job."
+            )
+        return bool(existing_batch_job or existing_pp_job)
 
     def upload_batch_files_to_cloud(self, tmppath):
         """Implements :func:`DockerBase.upload_batch_files_to_cloud`"""
@@ -970,11 +1004,10 @@ Run this script with --clean to clean up the GCP environment after post-processi
         # Monitor job/execution status, starting by polling the Job for an Execution
         logger.info("Waiting for execution to begin...")
         job_start_time = datetime.now()
-        jobs_client = run_v2.JobsClient()
-        job = jobs_client.get_job(name=self.postprocessing_job_name)
+        job = self.get_existing_postprocessing_job()
         while not job.latest_created_execution:
             time.sleep(1)
-            job = jobs_client.get_job(name=self.postprocessing_job_name)
+            job = self.get_existing_postprocessing_job()
         execution_start_time = datetime.now()
         logger.info(
             f"Execution has started (after {str(execution_start_time - job_start_time)} "
@@ -1037,15 +1070,13 @@ Run this script with --clean to clean up the GCP environment after post-processi
         tsv_logger.log_stats(logging.INFO)
 
     def clean_postprocessing_job(self):
-        jobs_client = run_v2.JobsClient()
         logger.info(
             "Cleaning post-processing Cloud Run job with "
             f"job_identifier='{self.job_identifier}'; "
             f"job name={self.postprocessing_job_name}..."
         )
-        try:
-            job = jobs_client.get_job(name=self.postprocessing_job_name)
-        except Exception:
+        job = self.get_existing_postprocessing_job()
+        if not job:
             logger.warning(
                 "Post-processing Cloud Run job not found for "
                 f"job_identifier='{self.job_identifier}' "
@@ -1076,6 +1107,7 @@ Run this script with --clean to clean up the GCP environment after post-processi
             return
 
         # ... The job succeeded or its execution was deleted successfully; it can be deleted
+        jobs_client = run_v2.JobsClient()
         try:
             jobs_client.delete_job(name=self.postprocessing_job_name)
         except Exception:
@@ -1193,19 +1225,15 @@ def main():
             batch.show_jobs()
             return
         elif args.postprocessonly:
+            if batch.check_for_existing_jobs(pp_only=True):
+                return
             batch.build_image()
             batch.push_image()
             batch.process_results()
         elif args.crawl:
             batch.process_results(skip_combine=True, use_dask_cluster=False)
         else:
-            existing_job = batch.get_existing_batch_job()
-            if existing_job:
-                job_status = existing_job.status.state.name
-                logger.error(
-                    f"A job with this ID ({batch.job_identifier}) already exists (status: {job_status}). "
-                    "Choose a new job_identifier or run with --clean to delete the existing job."
-                )
+            if batch.check_for_existing_jobs():
                 return
 
             batch.build_image()

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -456,9 +456,8 @@ class GcpBatch(DockerBatchBase):
         Show the existing GCP Batch and Cloud Run jobs that match the provided project, if they exist.
         """
         # GCP Batch job that runs the simulations
-        client = batch_v1.BatchServiceClient()
-        try:
-            job = client.get_job(batch_v1.GetJobRequest(name=self.gcp_batch_job_name))
+        job = self.get_existing_batch_job()
+        if job:
             logger.info("Batch job")
             logger.info(f"  Name: {job.name}")
             logger.info(f"  UID: {job.uid}")
@@ -469,7 +468,7 @@ class GcpBatch(DockerBatchBase):
                     task_counts[status] += count
             logger.info(f"  Task statuses: {dict(task_counts)}")
             logger.debug(f"Full job info:\n{job}")
-        except exceptions.NotFound:
+        else:
             logger.info(f"No existing Batch jobs match: {self.gcp_batch_job_name}")
         logger.info(f"See all Batch jobs at https://console.cloud.google.com/batch/jobs?project={self.gcp_project}")
 

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -506,23 +506,21 @@ class GcpBatch(DockerBatchBase):
     def check_for_existing_jobs(self, pp_only=False):
         """If there are existing jobs with the same ID as this job, logs them as errors and returns True.
 
-        Otherwise, returns False.
+        Checks for both the Batch job and Cloud Run post-processing job.
 
         :param pp_only: If true, only check for the post-processing job.
         """
         if pp_only:
             existing_batch_job = None
-        else:
-            if existing_batch_job := self.get_existing_batch_job():
-                logger.error(
-                    f"A Batch job with this ID ({self.job_identifier}) already exists "
-                    f"(status: {existing_batch_job.status.state.name}). Choose a new job_identifier or run with "
-                    "--clean to delete the existing job."
-                )
+        elif existing_batch_job := self.get_existing_batch_job():
+            logger.error(
+                f"A Batch job with this ID ({self.job_identifier}) already exists "
+                f"(status: {existing_batch_job.status.state.name}). Choose a new job_identifier or run with "
+                "--clean to delete the existing job."
+            )
+
         if existing_pp_job := self.get_existing_postprocessing_job():
-            status = "Running"
-            if existing_pp_job.latest_created_execution.completion_time:
-                status = "Completed"
+            status = "Completed" if existing_pp_job.latest_created_execution.completion_time else "Running"
             logger.error(
                 f"A Cloud Run job with this ID ({self.postprocessing_job_id}) already exists "
                 f"(status: {status}). Choose a new job_identifier or run with --clean "


### PR DESCRIPTION
Fail quickly if the user tries to start a job with the same ID as an existing job.

We still have the option to reattach to an existing job later, but for now we should at least fail early instead of after the Docker image has been built and pushed.