### PR TITLE
Add support for non-default service accounts

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -612,9 +612,8 @@ class GcpBatch(DockerBatchBase):
         )
         instances = batch_v1.AllocationPolicy.InstancePolicyOrTemplate(policy=policy)
         allocation_policy = batch_v1.AllocationPolicy(instances=[instances])
-        # TODO: Add option to set service account that runs the job?
-        # Otherwise uses the project's default compute engine service account.
-        # allocation_policy.service_account = batch_v1.ServiceAccount(email = '')
+        if service_account := gcp_cfg.get("service_account"):
+            allocation_policy.service_account = batch_v1.ServiceAccount(email=service_account)
 
         # Define the batch job
         job = batch_v1.Job()
@@ -945,6 +944,7 @@ class GcpBatch(DockerBatchBase):
                     ],
                     timeout=f"{60 * 60 * 24}s",  # 24h
                     max_retries=0,
+                    service_account=self.cfg["gcp"].get("service_account"),
                 )
             )
         )

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -25,6 +25,7 @@ gcp-spec:
   job_identifier: regex('^[a-z]([a-z0-9-]{0,46}[a-z0-9])?$', required=True)
   project: str(required=True)
   region: str(required=True)
+  service_account: str(required=False)
   artifact_registry: include('gcp-ar-spec', required=True)
   batch_array_size: num(min=1, max=10000, required=True)
   gcs: include('gcs-spec', required=True)

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -245,6 +245,8 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
    differentiate it from other jobs.
 *  ``project``: The GCP Project ID in which the batch will be run and of the Artifact Registry
    (where Docker images are stored).
+*  ``service_account``: The service account to use when running jobs on GCP.
+    Default: the Compute Engine default service account of the GCP project.
 *  ``gcs``: Configuration for project data storage on GCP Cloud Storage.
 
     *  ``bucket``: The Cloud Storage bucket this project will use for simulation output and
@@ -270,6 +272,7 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     *  ``use_spot``: true or false. Defaults to false if missing. This tells the project
        to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
        simulations, which can reduce costs by up to 91%.
+
 *  ``postprocessing_environment``: Optional. Specifies the Cloud Run computing environment for
    postprocessing.
 

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -245,7 +245,7 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
    differentiate it from other jobs.
 *  ``project``: The GCP Project ID in which the batch will be run and of the Artifact Registry
    (where Docker images are stored).
-*  ``service_account``: The service account to use when running jobs on GCP.
+*  ``service_account``: The service account email address to use when running jobs on GCP.
     Default: the Compute Engine default service account of the GCP project.
 *  ``gcs``: Configuration for project data storage on GCP Cloud Storage.
 
@@ -272,7 +272,6 @@ on the `GCP Batch <https://cloud.google.com/batch>`_ service.
     *  ``use_spot``: true or false. Defaults to false if missing. This tells the project
        to use `Spot VMs <https://cloud.google.com/spot-vms>`_ for data
        simulations, which can reduce costs by up to 91%.
-
 *  ``postprocessing_environment``: Optional. Specifies the Cloud Run computing environment for
    postprocessing.
 


### PR DESCRIPTION
GCP best practice is to use service accounts with the minimal required permissions, rather than relying on the [default compute engine service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account) which has broad edit access.

This change allows users to specify the service account to use when running both the GCP Batch and Cloud Run jobs.

I considered making this two separate fields within `gcp-job-environment-spec` and `gcp-postprocessing_environment-spec`, but it seemed unlikely that someone would want to use two different accounts for these steps.

Tested by doing a full run as natalie-dev@buildstockbatch-dev.iam.gserviceaccount.com.