### PR TITLE
Validate buildstock.csv before handling weather files

### DIFF
--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -149,10 +149,6 @@ class DockerBatchBase(BuildStockBatchBase):
         :returns: DockerBatchBase.BatchInfo
         """
 
-        # Weather files
-        logger.info("Prepping weather files...")
-        epws_to_copy = self._prep_weather_files_for_batch(tmppath)
-
         # Project configuration
         logger.info("Writing project configuration for upload")
         with open(tmppath / "config.json", "wt", encoding="utf-8") as f:
@@ -160,6 +156,10 @@ class DockerBatchBase(BuildStockBatchBase):
 
         # Collect simulations to queue
         batch_info = self._prep_jobs_for_batch(tmppath)
+
+        # Weather files
+        logger.info("Prepping weather files...")
+        epws_to_copy = self._prep_weather_files_for_batch(tmppath)
 
         return (epws_to_copy, batch_info)
 


### PR DESCRIPTION
Partially mitigates the issue described [here](https://www.notion.so/rewiringamerica/Items-to-discuss-7aac437cd05440cb9659d7ca123dc964?pvs=4#067262569da346bca9124339614c2ed1), in which inconsistencies between options_lookup.tsv and buildstock.csv can cause a job to fail.

**Context:**
We validate buildstock.csv [here](https://github.com/rewiringamerica/buildstockbatch/blob/7f3cae7c40d64348ba149611c17d74a98f842c61/buildstockbatch/cloud/docker_base.py#L245). Since this can't happen until after sampling is run, it's not easy to move into the `--validateonly` flow.

This change reorders some prep steps so that this validation happens sooner, so you don't have to wait through the weather file processing before finding out whether the validation passes.

In a quick test from my machine, this reduced the time to failure from ~4.5 minutes to ~2 minutes. (Most of the remaining time is building and pushing the docker image. This could also be moved to after sampling, but that's slightly more complicated, so I'm just sticking with this easy fix for now.)