### PR TITLE
Log summary of simulation statuses

### DIFF
--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -502,4 +502,8 @@ class DockerBatchBase(BuildStockBatchBase):
                 s += f"\nUpgrade {upgrade}   "
             for status in all_statuses:
                 s += f"{status}: {counts.get(status, 0):<7d}  "
+
+        for upgrade in postprocessing.get_upgrade_list(self.cfg):
+            if f"{upgrade:02d}" not in status_summary:
+                s += f"\nNo results found for Upgrade {upgrade}"
         logger.info(s)

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -474,26 +474,29 @@ class DockerBatchBase(BuildStockBatchBase):
         status_summary = {}
         all_statuses = set()
 
-        for result in fs.ls(f"{self.results_dir}/results_csvs/"):
-            upgrade_id = result.split(".")[0][-2:]
-            with fs.open(result) as f:
-                with gzip.open(f) as gf:
-                    df = pd.read_csv(gf)
-            # Dict mapping from status (e.g. "Success") to count
-            statuses = df.groupby("completed_status").size().to_dict()
-            status_summary[upgrade_id] = statuses
-            all_statuses.update(statuses.keys())
+        results_csv_dir = f"{self.results_dir}/results_csvs/"
+        try:
+            for result in fs.ls(results_csv_dir):
+                upgrade_id = result.split(".")[0][-2:]
+                with fs.open(result) as f:
+                    with gzip.open(f) as gf:
+                        df = pd.read_csv(gf, usecols=["completed_status"])
+                # Dict mapping from status (e.g. "Success") to count
+                statuses = df.groupby("completed_status").size().to_dict()
+                status_summary[upgrade_id] = statuses
+                all_statuses.update(statuses.keys())
 
-        # Always include these statuses and show them first
-        always_use = ["Success", "Fail"]
-        all_statuses = always_use + list(all_statuses - set(always_use))
-        s = "Final status of all simulations:"
-        for upgrade, counts in status_summary.items():
-            if upgrade == "00":
-                s += "\nBaseline     "
-            else:
-                s += f"\nUpgrade {upgrade}   "
-            for status in all_statuses:
-                s += f"{status}: {counts.get(status, 0):<6d} "
-
-        logger.info(s)
+            # Always include these statuses and show them first
+            always_use = ["Success", "Fail"]
+            all_statuses = always_use + list(all_statuses - set(always_use))
+            s = "Final status of all simulations:"
+            for upgrade, counts in status_summary.items():
+                if upgrade == "00":
+                    s += "\nBaseline     "
+                else:
+                    s += f"\nUpgrade {upgrade}   "
+                for status in all_statuses:
+                    s += f"{status}: {counts.get(status, 0):<7d}  "
+            logger.info(s)
+        except FileNotFoundError:
+            logger.info(f"No results CSV files found at {results_csv_dir}")

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -781,6 +781,7 @@ class GcpBatch(DockerBatchBase):
 
         if not skip_combine:
             self.start_combine_results_job_on_cloud(self.results_dir, do_timeseries=do_timeseries)
+        self.log_summary()
 
     @classmethod
     def run_combine_results_on_cloud(cls, gcs_bucket, gcs_prefix, results_dir, do_timeseries):

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -658,6 +658,7 @@ class GcpBatch(DockerBatchBase):
                 progress_bar.set_postfix_str(f"{dict(task_counts)}")
 
         logger.info(f"Batch job status: {job_status}")
+        logger.info(f"Batch job tasks: {dict(task_counts)}")
         if job_status != "SUCCEEDED":
             raise RuntimeError(f"Batch job failed. See GCP logs at {job_url}")
         else:


### PR DESCRIPTION
At the end of post-processing, print a summary of successful/failed/invalid simulations, grouped by upgrade.

Example output:
```
INFO:2023-12-15 16:30:59:buildstockbatch.cloud.docker_base:Final status of all simulations:
Baseline     Success: 8        Fail: 0        Invalid: 0        
Upgrade 01   Success: 8        Fail: 0        Invalid: 0        
Upgrade 02   Success: 8        Fail: 0        Invalid: 0        
Upgrade 03   Success: 8        Fail: 0        Invalid: 0        
Upgrade 04   Success: 2        Fail: 0        Invalid: 6        
Upgrade 05   Success: 8        Fail: 0        Invalid: 0        
Upgrade 06   Success: 0        Fail: 0        Invalid: 8        
Upgrade 07   Success: 8        Fail: 0        Invalid: 0        
Upgrade 08   Success: 8        Fail: 0        Invalid: 0        
Upgrade 09   Success: 8        Fail: 0        Invalid: 0        
Upgrade 10   Success: 8        Fail: 0        Invalid: 0        
Upgrade 11   Success: 8        Fail: 0        Invalid: 0        
Upgrade 12   Success: 8        Fail: 0        Invalid: 0        

Total        Success: 90       Fail: 0        Invalid: 14       

No results found for Upgrade 13
No results found for Upgrade 14
```

Future work:
- If useful, we could also show a few IDs of specific buildings that failed (to find them more quickly for debugging)
- Look for specific error messages in the logs and find a way to summarize those.