### PR TITLE
Update OpenStudio version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           wget --quiet https://data.nrel.gov/system/files/156/BuildStock_TMY3_FIPS.zip
       - name: Download and Install OpenStudio
         run: |
-          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.7.0-rc1/OpenStudio-3.7.0-rc1+211bb633b0-Ubuntu-22.04-x86_64.deb
-          sudo apt install -y ./OpenStudio-3.7.0-rc1+211bb633b0-Ubuntu-22.04-x86_64.deb
+          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.7.0/OpenStudio-3.7.0+d5269793f1-Ubuntu-22.04-x86_64.deb
+          sudo apt install -y ./OpenStudio-3.7.0+d5269793f1-Ubuntu-22.04-x86_64.deb
           openstudio openstudio_version
           which openstudio
       - name: Install buildstockbatch


### PR DESCRIPTION
Fixes broken CI workflow.

Corresponds to [this change](https://github.com/NREL/resstock/commit/4a9d942d20c29483a2aefc876de11b99462def59) in the ResStock test config files.
