### PR TITLE
Fix the ability to skip baseline sims in Docker-based implementations

### DIFF
--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -314,7 +314,10 @@ class DockerBatchBase(BuildStockBatchBase):
         self.validate_buildstock_csv(self.project_filename, df)
         building_ids = df.index.tolist()
         n_datapoints = len(building_ids)
-        n_sims = n_datapoints * (len(self.cfg.get("upgrades", [])) + 1)
+        if self.skip_baseline_sims:
+            n_sims = n_datapoints * len(self.cfg.get("upgrades", []))
+        else:
+            n_sims = n_datapoints * (len(self.cfg.get("upgrades", [])) + 1)
         logger.debug("Total number of simulations = {}".format(n_sims))
 
         # This is the maximum number of jobs that can be in an array
@@ -327,9 +330,12 @@ class DockerBatchBase(BuildStockBatchBase):
         logger.debug("Number of simulations per array job = {}".format(n_sims_per_job))
 
         # Create list of (building ID, upgrade to apply) pairs for all simulations to run.
-        baseline_sims = zip(building_ids, itertools.repeat(None))
         upgrade_sims = itertools.product(building_ids, range(len(self.cfg.get("upgrades", []))))
-        all_sims = list(itertools.chain(baseline_sims, upgrade_sims))
+        if not self.skip_baseline_sims:
+            baseline_sims = zip(building_ids, itertools.repeat(None))
+            all_sims = list(itertools.chain(baseline_sims, upgrade_sims))
+        else:
+            all_sims = list(itertools.chain(upgrade_sims))
         random.shuffle(all_sims)
         all_sims_iter = iter(all_sims)
 

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -335,7 +335,7 @@ class DockerBatchBase(BuildStockBatchBase):
             baseline_sims = zip(building_ids, itertools.repeat(None))
             all_sims = list(itertools.chain(baseline_sims, upgrade_sims))
         else:
-            all_sims = list(itertools.chain(upgrade_sims))
+            all_sims = list(upgrade_sims)
         random.shuffle(all_sims)
         all_sims_iter = iter(all_sims)
 

--- a/buildstockbatch/test/test_docker_base.py
+++ b/buildstockbatch/test/test_docker_base.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import os
 import pathlib
+import pytest
 import shutil
 import tarfile
 import tempfile
@@ -19,9 +20,11 @@ resources_dir = os.path.join(here, "test_inputs", "test_openstudio_buildstock", 
 
 
 @docker_available
-def test_skip_baseline_sims_false(basic_residential_project_file, mocker):
-    """Test that no "skip_sims" baseline configuration does not skip baseline sims."""
-    project_filename, results_dir = basic_residential_project_file()
+@pytest.mark.parametrize("skip_baseline_sims,expected", [(False, 10), (True, 5)])
+def test_skip_baseline_sims(basic_residential_project_file, mocker, skip_baseline_sims, expected):
+    """Test "skip_sims" baseline configuration's effect on ``n_sims``"""
+    update_args = {"baseline": {"skip_sims": True}} if skip_baseline_sims else {}
+    project_filename, results_dir = basic_residential_project_file(update_args)
 
     mocker.patch.object(DockerBatchBase, "results_dir", results_dir)
     sampler_property_mock = mocker.patch.object(DockerBatchBase, "sampler", new_callable=PropertyMock)
@@ -36,32 +39,7 @@ def test_skip_baseline_sims_false(basic_residential_project_file, mocker):
 
     with tempfile.TemporaryDirectory(prefix="bsb_") as tmpdir:
         _, batch_info = dbb._run_batch_prep(pathlib.Path(tmpdir))
-
-        assert batch_info.n_sims == 10
-
-
-@docker_available
-def test_skip_baseline_sims_true(basic_residential_project_file, mocker):
-    """Test that ``skip_sims: true`` baseline configuration skips baseline sims."""
-    project_filename, results_dir = basic_residential_project_file({"baseline": {"skip_sims": True}})
-
-    mocker.patch.object(DockerBatchBase, "results_dir", results_dir)
-    sampler_property_mock = mocker.patch.object(DockerBatchBase, "sampler", new_callable=PropertyMock)
-    sampler_mock = mocker.MagicMock()
-    sampler_property_mock.return_value = sampler_mock
-    # Hard-coded sampling output includes 5 buildings.
-    sampler_mock.run_sampling = MagicMock(return_value=os.path.join(resources_dir, "buildstock_good.csv"))
-
-    dbb = DockerBatchBase(project_filename)
-    dbb.batch_array_size = 3
-    DockerBatchBase.validate_project = MagicMock(return_value=True)
-
-    print(f"dbb.skip_baseline_sims={dbb.skip_baseline_sims}")
-
-    with tempfile.TemporaryDirectory(prefix="bsb_") as tmpdir:
-        _, batch_info = dbb._run_batch_prep(pathlib.Path(tmpdir))
-
-        assert batch_info.n_sims == 5
+        assert batch_info.n_sims == expected
 
 
 @docker_available


### PR DESCRIPTION
## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] ~Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)~
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] ~Update validation for project config yaml file changes~
- [ ] ~Update existing documentation~
- [ ] ~Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle~
- [ ] ~Add to the changelog_dev.rst file and propose migration text in the pull request~
