### PR TITLE
Turn off external IPs

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -168,7 +168,7 @@ class GcpBatch(DockerBatchBase):
             assert len(job_identifier) <= 48, "Job identifier must be no longer than 48 characters."
             assert re.match(
                 "^[a-z]([a-z0-9-]{0,46}[a-z0-9])?$", job_identifier
-            ), "Job identifer must start with a letter and contain only letters, numbers, and hyphens."
+            ), "Job identifer must start with a letter and contain only lowercase letters, numbers, and hyphens."
             self.job_identifier = job_identifier
         else:
             self.job_identifier = self.cfg["gcp"]["job_identifier"]
@@ -610,7 +610,28 @@ class GcpBatch(DockerBatchBase):
             ),
         )
         instances = batch_v1.AllocationPolicy.InstancePolicyOrTemplate(policy=policy)
-        allocation_policy = batch_v1.AllocationPolicy(instances=[instances])
+        # Make sure the default subnet for this region has access to Google APIs when external IP addresses are blocked.
+        subnet_client = compute_v1.SubnetworksClient()
+        subnet_client.set_private_ip_google_access(
+            project=self.gcp_project,
+            region=self.region,
+            subnetwork="default",
+            subnetworks_set_private_ip_google_access_request_resource=compute_v1.SubnetworksSetPrivateIpGoogleAccessRequest(  # noqa
+                private_ip_google_access=True
+            ),
+        )
+        allocation_policy = batch_v1.AllocationPolicy(
+            instances=[instances],
+            network=batch_v1.AllocationPolicy.NetworkPolicy(
+                network_interfaces=[
+                    batch_v1.AllocationPolicy.NetworkInterface(
+                        network="global/networks/default",
+                        subnetwork=f"regions/{self.region}/subnetworks/default",
+                        no_external_ip_address=True,
+                    )
+                ]
+            ),
+        )
         if service_account := gcp_cfg.get("service_account"):
             allocation_policy.service_account = batch_v1.ServiceAccount(email=service_account)
 


### PR DESCRIPTION
Configure our Compute Engine VMs (created via Batch) to not use external IPs. We don't need them, and we're hitting quota limits on the number of external IP addresses in use.

Also ensure that the relevant subnet has Private Google Access enabled so the jobs can access Google APIs. (This is using the [default VPC network](https://cloud.google.com/vpc/docs/vpc#default-network), which [has a subnet in every region](https://cloud.google.com/vpc/docs/subnets#vpc_networks_and_subnets).)

Testing: Successfully ran a test job and confirmed that the created VMs did not have external IPs:
<img width="1072" alt="image" src="https://github.com/rewiringamerica/buildstockbatch/assets/1621724/9c9b86d6-aa26-4b83-9d74-5c3c581d8b7d">
