### PR TITLE
Clean up docker containers

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -550,10 +550,10 @@ class GcpBatch(DockerBatchBase):
         logger.info("Setting up GCP Batch job")
         client = batch_v1.BatchServiceClient()
 
-        runnable = batch_v1.Runnable()
-        runnable.container = batch_v1.Runnable.Container()
-        runnable.container.image_uri = self.repository_uri + ":" + self.job_identifier
-        runnable.container.entrypoint = "/bin/sh"
+        bsb_runnable = batch_v1.Runnable()
+        bsb_runnable.container = batch_v1.Runnable.Container()
+        bsb_runnable.container.image_uri = self.repository_uri + ":" + self.job_identifier
+        bsb_runnable.container.entrypoint = "/bin/sh"
 
         # Pass environment variables to each task
         environment = batch_v1.Environment()
@@ -563,13 +563,16 @@ class GcpBatch(DockerBatchBase):
             "GCS_PREFIX": self.gcs_prefix,
             "GCS_BUCKET": self.gcs_bucket,
         }
-        runnable.environment = environment
+        bsb_runnable.environment = environment
 
-        runnable.container.commands = ["-c", "python3 -m buildstockbatch.gcp.gcp"]
+        bsb_runnable.container.commands = ["-c", "python3 -m buildstockbatch.gcp.gcp"]
 
-        prune = batch_v1.Runnable()
-        prune.script = batch_v1.Runnable.Script()
-        prune.script.text = "docker system prune --volumes -f"
+        cleanup_runnable = batch_v1.Runnable()
+        cleanup_runnable.script = batch_v1.Runnable.Script()
+        # Prune old docker containers after we're done using them, so they don't use up all the disk space.
+        # "until=2m" - Ignore containers that were just created and aren't active yet.
+        # "|| true" - This can fail if another task is pruning at the same time, but these failures are safe to ignore.
+        cleanup_runnable.script.text = 'docker system prune -f --filter "until=2m" || true'
 
         gcp_cfg = self.cfg["gcp"]
         job_env_cfg = gcp_cfg.get("job_environment", {})
@@ -581,7 +584,7 @@ class GcpBatch(DockerBatchBase):
         # Give three minutes per simulation, plus ten minutes for job overhead
         task_duration_secs = 60 * (10 + batch_info.n_sims_per_job * 3)
         task = batch_v1.TaskSpec(
-            runnables=[runnable, prune],
+            runnables=[bsb_runnable, cleanup_runnable],
             compute_resource=resources,
             # Allow retries, but only when the machine is preempted.
             max_retry_count=3,

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -567,6 +567,10 @@ class GcpBatch(DockerBatchBase):
 
         runnable.container.commands = ["-c", "python3 -m buildstockbatch.gcp.gcp"]
 
+        prune = batch_v1.Runnable()
+        prune.script = batch_v1.Runnable.Script()
+        prune.script.text = "docker system prune --volumes -f"
+
         gcp_cfg = self.cfg["gcp"]
         job_env_cfg = gcp_cfg.get("job_environment", {})
         resources = batch_v1.ComputeResource(
@@ -577,7 +581,7 @@ class GcpBatch(DockerBatchBase):
         # Give three minutes per simulation, plus ten minutes for job overhead
         task_duration_secs = 60 * (10 + batch_info.n_sims_per_job * 3)
         task = batch_v1.TaskSpec(
-            runnables=[runnable],
+            runnables=[runnable, prune],
             compute_resource=resources,
             # Allow retries, but only when the machine is preempted.
             max_retry_count=3,

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -567,9 +567,9 @@ class GcpBatch(DockerBatchBase):
 
         bsb_runnable.container.commands = ["-c", "python3 -m buildstockbatch.gcp.gcp"]
 
+        # Prune old docker containers after we're done using them, so they don't use up all the disk space.
         cleanup_runnable = batch_v1.Runnable()
         cleanup_runnable.script = batch_v1.Runnable.Script()
-        # Prune old docker containers after we're done using them, so they don't use up all the disk space.
         # "until=2m" - Ignore containers that were just created and aren't active yet.
         # "|| true" - This can fail if another task is pruning at the same time, but these failures are safe to ignore.
         cleanup_runnable.script.text = 'docker system prune -f --filter "until=2m" || true'


### PR DESCRIPTION
Clean up our docker containers at the end of each task.

This should be handled by GCP Batch, but since it's not, do it ourselves.

Tested:
- Before this change, containers would build up as multiple tasks ran on the same VM. For example:
```
$ docker system df
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          1         1         4.53GB    0B (0%)
Containers      9         4         1.205GB   533.3MB (44%)
Local Volumes   9         9         977.4MB   0B (0%)
Build Cache     0         0         0B        0B
```
- With this change, they are cleaned up along the way:
```
$ docker system df
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          1         1         4.531GB   0B (0%)
Containers      3         3         99.8MB    0B (0%)
Local Volumes   3         3         409.4MB   0B (0
```