### PR TITLE
Add bsb_job_identifier label to more of the GCP resources used by the Batch

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -548,12 +548,15 @@ class GcpBatch(DockerBatchBase):
         """Implements :func:`DockerBase.start_batch_job`"""
         # Define and run the GCP Batch job.
         logger.info("Setting up GCP Batch job")
+        labels = {"bsb_job_identifier": self.job_identifier}
+
         client = batch_v1.BatchServiceClient()
 
         runnable = batch_v1.Runnable()
         runnable.container = batch_v1.Runnable.Container()
         runnable.container.image_uri = self.repository_uri + ":" + self.job_identifier
         runnable.container.entrypoint = "/bin/sh"
+        runnable.labels = labels
 
         # Pass environment variables to each task
         environment = batch_v1.Environment()
@@ -610,7 +613,10 @@ class GcpBatch(DockerBatchBase):
             ),
         )
         instances = batch_v1.AllocationPolicy.InstancePolicyOrTemplate(policy=policy)
-        allocation_policy = batch_v1.AllocationPolicy(instances=[instances])
+        allocation_policy = batch_v1.AllocationPolicy(
+            instances=[instances],
+            labels=labels,
+        )
         if service_account := gcp_cfg.get("service_account"):
             allocation_policy.service_account = batch_v1.ServiceAccount(email=service_account)
 
@@ -620,9 +626,7 @@ class GcpBatch(DockerBatchBase):
         job.allocation_policy = allocation_policy
         job.logs_policy = batch_v1.LogsPolicy()
         job.logs_policy.destination = batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
-        job.labels = {
-            "bsb_job_identifier": self.job_identifier,
-        }
+        job.labels = labels
 
         create_request = batch_v1.CreateJobRequest()
         create_request.job = job


### PR DESCRIPTION
...especially Compute Engine (via AllocationPolicy) for cost analysis.

Project run 'robertl-ntlup-20240109-500x18-p256' [shows a cost of $0.80 in the billing report](https://console.cloud.google.com/billing/0105F7-03D2DC-110201/reports;projects=buildstockbatch-dev;labels=bsb_job_identifier:robertl-ntlup-20240109-500x18-p256;credits=NONE?project=buildstockbatch-dev), which is fairly close to [the estimated cost of $0.65 in our calculator](https://docs.google.com/spreadsheets/d/1CoNwzVT_9r6KIXinwd0_PoCtfgL8y470AKsyf7UtJKE/edit#gid=290943411&range=Y39).