### PR TITLE
Skip optional deletion with missingonly flag

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -220,37 +220,45 @@ class GcpBatch(DockerBatchBase):
             blobs_exist = True
             break
 
-        if not self.missing_only:
-            if blobs_exist:
-                prefix_for_deletion = os.path.join(cfg["gcp"]["gcs"]["prefix"])
-                blobs_for_deletion = storage_client.bucket(bucket).list_blobs(prefix=prefix_for_deletion)
-            
-                user_choice = input(f"Output files are already present in bucket {bucket}! For example, {blob.name} exists. "
-                            "Do you want to delete all the files in {prefix_for_deletion}? (yes/no): ").strip().lower()
+        
+        if blobs_exist:
+            prefix_for_deletion = cfg["gcp"]["gcs"]["prefix"]
+            blobs_for_deletion = storage_client.bucket(bucket).list_blobs(prefix=prefix_for_deletion)
+        
+            user_choice = input(f"Output files are already present in bucket {bucket}! For example, {blob.name} exists. "
+                        f"Do you want to delete all the files in {prefix_for_deletion}? (yes/no): ").strip().lower()
 
-                if user_choice == "yes":
-                    for blob in blobs_for_deletion:
-                        try:
-                            blob.delete()
-                        except Exception as e:
-                            print(f"Failed to delete {blob.name}: {e}")
+            if user_choice == "yes":
+                for blob in blobs_for_deletion:
+                    try:
+                        blob.delete()
+                    except Exception as e:
+                        print(f"Failed to delete {blob.name}: {e}")
 
-                    # Confirm deletion
-                    remaining_blobs = list(storage_client.bucket(bucket).list_blobs(prefix=os.path.join(output_dir, "results_job")))
-                    if not remaining_blobs:
-                        print("All specified files have been confirmed deleted. You can now proceed with your operation.")
-                    else:
-                        print(f"Deletion confirmed for some files, but some still remain. Please check GCS for details.")
+                # Confirm deletion
+                remaining_blobs = list(storage_client.bucket(bucket).list_blobs(prefix=prefix_for_deletion))
+                if not remaining_blobs:
+                    print("All specified files have been confirmed deleted. You can now proceed with your operation.")
+                else:
+                    print(f"Deletion confirmed for some files, but some still remain. Please check GCS for details.")
 
-                elif user_choice == "no":
+            elif user_choice == "no":
+                user_choice_missing = input(f"Output files are already present in bucket {bucket}!"
+                        "Is this a missingonly run? (yes/no): ").strip().lower()
+
+                if user_choice_missing == "no":
                     raise ValidationError(
                     f"Output files are already present in bucket {bucket}! For example, {blob.name} exists. "
                     "If you do not wish to delete them choose a different file prefix. "
                     f"https://console.cloud.google.com/storage/browser/{bucket}/{prefix_for_deletion}"
                 )
-                else:
-                    raise ValidationError(
-                    f"Invalid input!")
+
+                if user_choice_missing == "yes":
+                    print(f"This is a run with --missingonly flag. Output files can remain in bucket {bucket}")
+            
+            else:
+                raise ValidationError(
+                f"Invalid input!")
 
         # Check that artifact registry repository exists
         repo = cfg["gcp"]["artifact_registry"]["repository"]


### PR DESCRIPTION
Fixes # .

## Pull Request Description

This fix should skip the optional prefix deletion while `--missingonly` flag is active. 

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
