### PR TITLE
Clean up output dir validation

### DIFF
--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -558,9 +558,12 @@ class DockerBatchBase(BuildStockBatchBase):
         fs = self.get_fs()
         done_tasks = set()
 
-        for f in fs.ls(f"{self.results_dir}/simulation_output/"):
-            if m := re.match(".*results_job(\\d*).json.gz$", f):
-                done_tasks.add(int(m.group(1)))
+        try:
+            for f in fs.ls(f"{self.results_dir}/simulation_output/"):
+                if m := re.match(".*results_job(\\d*).json.gz$", f):
+                    done_tasks.add(int(m.group(1)))
+        except FileNotFoundError:
+            logger.warning("No completed task files found. Running all tasks.")
 
         missing_tasks = []
         with fs.open(f"{self.results_dir}/missing_tasks.txt", "w") as f:

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -190,8 +190,57 @@ class GcpBatch(DockerBatchBase):
         """Returns the full name of a repository in Artifact Registry."""
         return f"projects/{gcp_project}/locations/{region}/repositories/{repo}"
 
+    def check_output_dir(self):
+        """Check for existing files in the output directory."""
+        if self.missing_only:
+            return
+        cfg = self.cfg
+        storage_client = storage.Client(project=self.gcp_project)
+        output_dir = os.path.join(cfg["gcp"]["gcs"]["prefix"], "results", "simulation_output")
+        bucket = storage_client.bucket(self.gcs_bucket)
+        blobs = bucket.list_blobs(prefix=os.path.join(output_dir, "results_job"))
+
+        try:
+            blob = next(blobs)
+        except StopIteration:
+            return
+
+        prefix_for_deletion = cfg["gcp"]["gcs"]["prefix"]
+        blobs_for_deletion = bucket.list_blobs(prefix=prefix_for_deletion)
+        user_choice = (
+            input(
+                f"Output files are already present in bucket {self.gcs_bucket}! For example, {blob.name} exists. "
+                f"Do you want to delete all the files in {prefix_for_deletion}? (yes/no): "
+            )
+            .strip()
+            .lower()
+        )
+
+        if user_choice == "yes":
+            print("Deleting files...")
+            try:
+                blobs_for_deletion_object = [blob for blob in blobs_for_deletion]
+                bucket.delete_blobs(blobs_for_deletion_object)
+            except Exception as e:
+                print(f"Failed to delete files: {e}")
+
+            # Confirm deletion
+            remaining_blobs = list(bucket.list_blobs(prefix=prefix_for_deletion))
+            if not remaining_blobs:
+                print("All specified files have been confirmed deleted. You can now proceed with your operation.")
+            else:
+                print("Deletion confirmed for some files, but some still remain. Please check GCS for details.")
+        elif user_choice == "no":
+            raise ValidationError(
+                f"Output files are already present in bucket {self.gcs_bucket}! For example, {blob.name} exists. "
+                "If you do not wish to delete them choose a different file prefix. "
+                f"https://console.cloud.google.com/storage/browser/{self.gcs_bucket}/{prefix_for_deletion}"
+            )
+        else:
+            raise ValidationError("Invalid input!")
+
     @staticmethod
-    def validate_gcp_args(project_file, missing_only):
+    def validate_gcp_args(project_file):
         cfg = get_project_configuration(project_file)
         assert "gcp" in cfg, 'Project config must contain a "gcp" section'
         gcp_project = cfg["gcp"]["project"]
@@ -209,49 +258,8 @@ class GcpBatch(DockerBatchBase):
 
         # Check that GCP bucket exists
         bucket = cfg["gcp"]["gcs"]["bucket"]
-        output_dir = os.path.join(cfg["gcp"]["gcs"]["prefix"], "results", "simulation_output")
         storage_client = storage.Client(project=gcp_project)
         assert storage_client.bucket(bucket).exists(), f"GCS bucket {bucket} does not exist in project {gcp_project}"
-
-        blobs_exist = False
-        blobs = storage_client.bucket(bucket).list_blobs(prefix=os.path.join(output_dir, "results_job"))
-
-        for blob in blobs:
-            blobs_exist = True
-            break
-
-        if not missing_only: 
-            if blobs_exist:
-                prefix_for_deletion = cfg["gcp"]["gcs"]["prefix"]
-                blobs_for_deletion = storage_client.bucket(bucket).list_blobs(prefix=prefix_for_deletion)
-        
-                user_choice = input(f"Output files are already present in bucket {bucket}! For example, {blob.name} exists. "
-                            f"Do you want to delete all the files in {prefix_for_deletion}? (yes/no): ").strip().lower()
-
-                if user_choice == "yes":
-                    try:
-                        blobs_for_deletion_object = [blob for blob in blobs_for_deletion]
-                        storage_client.bucket(bucket).delete_blobs(blobs_for_deletion_object)
-                    except Exception as e:
-                        print(f"Failed to delete files: {e}")
-
-                    # Confirm deletion
-                    remaining_blobs = list(storage_client.bucket(bucket).list_blobs(prefix=prefix_for_deletion))
-                    if not remaining_blobs:
-                        print("All specified files have been confirmed deleted. You can now proceed with your operation.")
-                    else:
-                        print(f"Deletion confirmed for some files, but some still remain. Please check GCS for details.")
-
-                elif user_choice == "no":
-                    raise ValidationError(
-                    f"Output files are already present in bucket {bucket}! For example, {blob.name} exists. "
-                    "If you do not wish to delete them choose a different file prefix. "
-                    f"https://console.cloud.google.com/storage/browser/{bucket}/{prefix_for_deletion}"
-                )
-            
-                else:
-                    raise ValidationError(
-                    f"Invalid input!")
 
         # Check that artifact registry repository exists
         repo = cfg["gcp"]["artifact_registry"]["repository"]
@@ -291,9 +299,9 @@ class GcpBatch(DockerBatchBase):
             )
 
     @staticmethod
-    def validate_project(project_file, missing_only=False):
+    def validate_project(project_file):
         super(GcpBatch, GcpBatch).validate_project(project_file)
-        GcpBatch.validate_gcp_args(project_file,missing_only)
+        GcpBatch.validate_gcp_args(project_file)
 
     @property
     def docker_image(self):
@@ -1226,7 +1234,7 @@ def main():
             logger.setLevel(logging.INFO)
 
         # validate the project, and if --validateonly flag is set, return True if validation passes
-        GcpBatch.validate_project(os.path.abspath(args.project_filename), args.missingonly)
+        GcpBatch.validate_project(os.path.abspath(args.project_filename))
         if args.validateonly:
             return True
 
@@ -1246,6 +1254,7 @@ def main():
         else:
             if batch.check_for_existing_jobs():
                 return
+            batch.check_output_dir()
 
             batch.build_image()
             batch.push_image()

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -192,8 +192,6 @@ class GcpBatch(DockerBatchBase):
 
     def check_output_dir(self):
         """Check for existing results files in the output directory."""
-        if self.missing_only:
-            return
         storage_client = storage.Client(project=self.gcp_project)
         output_dir = os.path.join(self.cfg["gcp"]["gcs"]["prefix"], "results", "simulation_output")
         bucket = storage_client.bucket(self.gcs_bucket)
@@ -209,7 +207,7 @@ class GcpBatch(DockerBatchBase):
         user_choice = (
             input(
                 f"Output files are already present in bucket {self.gcs_bucket}! For example, {blob.name} exists. "
-                f"Do you want to delete all the files in {prefix_for_deletion}? (yes/no): "
+                f"Do you want to permanently delete all the files in {prefix_for_deletion}? (yes/no): "
             )
             .strip()
             .lower()
@@ -1255,7 +1253,8 @@ def main():
         else:
             if batch.check_for_existing_jobs():
                 return
-            batch.check_output_dir()
+            if not args.missingonly:
+                batch.check_output_dir()
 
             batch.build_image()
             batch.push_image()


### PR DESCRIPTION
This moves the "check for existing files in the output dir" step out of the validation function.

There are enough cases where we do validation but don't want to do this check that I think it makes sense to keep it separate. (`--missingonly`, `--clean`, `--postprocessonly`, `--showjobs`)