### PR TITLE
Separate GCP dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd buildstockbatch
           python -m pip install --progress-bar off --upgrade pip
-          pip install .[dev,gcp] --progress-bar off
+          pip install .[dev] --progress-bar off
       - name: Linting
         run: |
           cd buildstockbatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd buildstockbatch
           python -m pip install --progress-bar off --upgrade pip
-          pip install .[dev] --progress-bar off
+          pip install .[dev,gcp] --progress-bar off
       - name: Linting
         run: |
           cd buildstockbatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 ARG OS_VER
 FROM --platform=linux/amd64 nrel/openstudio:$OS_VER as buildstockbatch
+ARG CLOUD_PLATFORM
 
 RUN sudo apt update && sudo apt install -y python3-pip
 RUN sudo -H pip install --upgrade pip
 COPY . /buildstock-batch/
-RUN python3 -m pip install "/buildstock-batch[gcp]"
+RUN python3 -m pip install "/buildstock-batch[${CLOUD_PLATFORM}]"
 
 # Base plus custom gems
 FROM buildstockbatch as buildstockbatch-custom-gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 nrel/openstudio:$OS_VER as buildstockbatch
 RUN sudo apt update && sudo apt install -y python3-pip
 RUN sudo -H pip install --upgrade pip
 COPY . /buildstock-batch/
-RUN python3 -m pip install "/buildstock-batch"
+RUN python3 -m pip install "/buildstock-batch[gcp]"
 
 # Base plus custom gems
 FROM buildstockbatch as buildstockbatch-custom-gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG OS_VER
 FROM --platform=linux/amd64 nrel/openstudio:$OS_VER as buildstockbatch
-ARG CLOUD_PLATFORM
+ARG CLOUD_PLATFORM=aws
 
 RUN sudo apt update && sudo apt install -y python3-pip
 RUN sudo -H pip install --upgrade pip

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -1530,7 +1530,9 @@ class AwsBatch(DockerBatchBase):
         if not (root_path / "Dockerfile").exists():
             raise RuntimeError(f"The needs to be run from the root of the repo, found {root_path}")
         logger.debug("Building docker image")
-        self.docker_client.images.build(path=str(root_path), tag=self.docker_image, rm=True)
+        self.docker_client.images.build(
+            path=str(root_path), tag=self.docker_image, rm=True, buildargs={"CLOUD_PLATFORM": "aws"}
+        )
 
     def push_image(self):
         """

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -390,7 +390,7 @@ class GcpBatch(DockerBatchBase):
             rm=True,
             target=stage,
             platform="linux/amd64",
-            buildargs={"OS_VER": self.os_version},
+            buildargs={"OS_VER": self.os_version, "CLOUD_PLATFORM": "gcp"},
         )
         build_image_log = os.path.join(local_log_dir, "build_image.log")
         with open(build_image_log, "w") as f_out:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -295,6 +295,7 @@ manage BuildStockBatch runs.
 2. Get BuildStockBatch and set up a Python environment for it using the :ref:`python` instructions
    above. (i.e., create a Python virtual environment, activate the venv, and install buildstockbatch
    with the command below.)
+
    * Install with the ``[gcp]`` option to include GCP-specific dependencies:
 
     ::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -293,8 +293,15 @@ manage BuildStockBatch runs.
 
 1. Install `Docker`_. This is needed by the script to manage Docker images (pull, push, etc).
 2. Get BuildStockBatch and set up a Python environment for it using the :ref:`python` instructions
-   above (i.e., create a Python virtual environment, activate the venv, and install buildstockbatch
-   to it).
+   above. (i.e., create a Python virtual environment, activate the venv, and install buildstockbatch
+   with the command below.)
+   * Install with the ``[gcp]`` option to include GCP-specific dependencies:
+
+    ::
+
+        cd /path/to/buildstockbatch
+        python -m pip install -e ".[gcp]"
+
 3. Download/Clone ResStock or ComStock.
 4. Set up GCP authentication.
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,16 @@ with open(os.path.join(here, "buildstockbatch", "__version__.py"), "r", encoding
 with open("README.md", "r", "utf-8") as f:
     readme = f.read()
 
+gcp_requires = [
+    "gcsfs",
+    "google-cloud-artifact-registry",
+    "google-cloud-batch",
+    "google-cloud-compute",
+    "google-cloud-run",
+    "google-cloud-storage",
+    "tqdm",
+]
+
 setuptools.setup(
     name=metadata["__title__"],
     version=metadata["__version__"],
@@ -60,16 +70,9 @@ setuptools.setup(
             "rope",
             "doc8",
             "pre-commit",
-        ],
-        "gcp": [
-            "gcsfs",
-            "google-cloud-artifact-registry",
-            "google-cloud-batch",
-            "google-cloud-compute",
-            "google-cloud-run",
-            "google-cloud-storage",
-            "tqdm",
-        ],
+        ]
+        + gcp_requires,
+        "gcp": gcp_requires,
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,6 @@ setuptools.setup(
         "awsretry",
         "lxml",
         "semver",
-        "gcsfs",
-        "google-cloud-artifact-registry",
-        "google-cloud-batch",
-        "google-cloud-compute",
-        "google-cloud-run",
-        "google-cloud-storage",
-        "tqdm",
     ],
     extras_require={
         "dev": [
@@ -67,7 +60,16 @@ setuptools.setup(
             "rope",
             "doc8",
             "pre-commit",
-        ]
+        ],
+        "gcp": [
+            "gcsfs",
+            "google-cloud-artifact-registry",
+            "google-cloud-batch",
+            "google-cloud-compute",
+            "google-cloud-run",
+            "google-cloud-storage",
+            "tqdm",
+        ],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setuptools.setup(
         ]
         + gcp_requires,
         "gcp": gcp_requires,
+        "aws": [],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Move GCP dependencies to a separate section, so they aren't installed by default.

This follows the same model the AWS code is moving toward [here](https://github.com/NREL/buildstockbatch/blob/a015e3f74d01a33ca65efdb9598a0016e63f9ff8/setup.py#L64).