### PR TITLE
Add config option for simulation duration

### DIFF
--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -654,8 +654,9 @@ class GcpBatch(DockerBatchBase):
             boot_disk_mib=job_env_cfg.get("boot_disk_mib", None),
         )
 
-        # Give three minutes per simulation, plus ten minutes for job overhead
-        task_duration_secs = 60 * (10 + batch_info.n_sims_per_job * 3)
+        # Use specified time per simulation, plus ten minutes for job overhead.
+        minutes_per_sim = job_env_cfg.get("minutes_per_sim", 3)
+        task_duration_secs = 60 * (10 + batch_info.n_sims_per_job * minutes_per_sim)
         task = batch_v1.TaskSpec(
             runnables=[bsb_runnable],
             compute_resource=resources,

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -48,6 +48,7 @@ gcp-job-environment-spec:
   boot_disk_mib: int(required=False)
   machine_type: str(required=False)
   use_spot: bool(required=False)
+  minutes_per_sim: num(min=0.05, max=480, required=False)
 
 gcp-postprocessing_environment-spec:
   # Limits documented at

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -333,6 +333,8 @@ using `GCP Batch <https://cloud.google.com/batch>`_ and `Cloud Run <https://clou
        this is a type from the `E2 series`_. Usually safe to leave unset.
     *  ``use_spot``: Optional. Whether to use `Spot VMs <https://cloud.google.com/spot-vms>`_
        for data simulations, which can reduce costs by up to 91%. Default: false
+    *  ``minutes_per_sim``: Optional. Maximum time per simulation. Default works well for ResStock,
+       but this should be increased for ComStock. Default: 3 minutes
 *  ``postprocessing_environment``: Optional. Specifies the Cloud Run computing environment for
    postprocessing.
 


### PR DESCRIPTION
Make max duration configurable.

Based on a comment on https://github.com/NREL/buildstockbatch/pull/423, make this configurable because ComStock simulations can be much slower. I followed the example of `minutes_per_sim` in `hpc-spec`.

The default behavior is unchanged.